### PR TITLE
[WIP] upgrade to http 5 - breaks the specs, unfortunately.

### DIFF
--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_dependency 'buftok', '~> 0.2.0'
   spec.add_dependency 'equalizer', '~> 0.0.11'
-  spec.add_dependency 'http', '~> 4.0'
+  spec.add_dependency 'http', '~> 5.0'
   spec.add_dependency 'http-form_data', '~> 2.0'
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
   spec.add_dependency 'memoizable', '~> 0.4.0'


### PR DESCRIPTION
+ we're blocked from upgrading Juicer to http 5 currently.
+ this removes the version pin in the `http` gem but currently breaks the gem's specs :(
+ leaving this PR for later

### TODOs
+ [ ] fix the `twitter` gem's specs, the upgrade from `http` 4 to 5 contains breaking changes.